### PR TITLE
Install latest drupal version with PHP upgrade

### DIFF
--- a/scripts/install_drupal.sh
+++ b/scripts/install_drupal.sh
@@ -14,11 +14,12 @@ if [[ $use_shared_storage == "true" ]]; then
   echo "NFS share mounted."
   cd ${drupal_shared_working_dir}
 else
-  echo "No mount NFS share. Moving to /var/www/html" 
-  cd /var/www/	
+  echo "No mount NFS share. Moving to /var/www/html"
+  cd /var/www/
 fi
 
-wget https://www.drupal.org/download-latest/tar.gz
+#To download latest drupal
+wget https://www.drupal.org/download-latest/tar.gz -O drupal.tar.gz
 
 if [[ $use_shared_storage == "true" ]]; then
   tar zxvf tar.gz --directory ${drupal_shared_working_dir}
@@ -31,7 +32,7 @@ else
   mv drupal-* html
   cd html
   cp sites/default/default.settings.php sites/default/settings.php
-fi 
+fi
 
 if [[ $use_shared_storage == "true" ]]; then
   echo "... Changing /etc/httpd/conf/httpd.conf with Document set to new shared NFS space ..."

--- a/scripts/install_drupal.sh
+++ b/scripts/install_drupal.sh
@@ -22,13 +22,13 @@ fi
 wget https://www.drupal.org/download-latest/tar.gz -O drupal.tar.gz
 
 if [[ $use_shared_storage == "true" ]]; then
-  tar zxvf tar.gz --directory ${drupal_shared_working_dir}
+  tar zxvf drupal.tar.gz --directory ${drupal_shared_working_dir}
   cp -r ${drupal_shared_working_dir}/drupal-*/* ${drupal_shared_working_dir}
   rm -rf ${drupal_shared_working_dir}/drupal-*
   cp ${drupal_shared_working_dir}/sites/default/default.settings.php sites/default/settings.php
 else
-  tar zxvf tar.gz
-  rm -rf html/ tar.gz
+  tar zxvf drupal.tar.gz
+  rm -rf html/ drupal.tar.gz
   mv drupal-* html
   cd html
   cp sites/default/default.settings.php sites/default/settings.php

--- a/scripts/install_php74.sh
+++ b/scripts/install_php74.sh
@@ -18,10 +18,10 @@ echo "MySQL Shell successfully installed !"
 
 if [[ $(uname -r | sed 's/^.*\(el[0-9]\+\).*$/\1/') == "el8" ]]
 then
-  dnf -y module enable php:remi-8.2
+  dnf -y module enable php:remi-8.4
   dnf -y install php php-cli php-mysqlnd php-zip php-gd php-mcrypt php-mbstring php-xml php-json php-opcache
 else
-  yum-config-manager --enable remi-php82
+  yum-config-manager --enable remi-php84
   yum -y install php php-cli php-mysqlnd php-zip php-gd php-mcrypt php-mbstring php-xml php-json php-opcache
 fi
 


### PR DESCRIPTION
Tested for Drupal latest version drupal 11.2.2 released on 26 Jun 2025 at 14:01 UTC.


<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1d5d9c96-60ad-4ccd-a0e4-49466200556b" />
